### PR TITLE
fix: Copilot review bugs — delete guard, INVALID_ARGUMENT, TOCTOU

### DIFF
--- a/src/main/java/ai/pipestream/connector/repository/ConnectorRegistrationRepository.java
+++ b/src/main/java/ai/pipestream/connector/repository/ConnectorRegistrationRepository.java
@@ -219,6 +219,15 @@ public class ConnectorRegistrationRepository {
         );
     }
 
+    /**
+     * Checks if any ConnectorConfigSchema belongs to this connector type (reactive).
+     */
+    public Uni<Boolean> hasSchemas(String connectorId) {
+        return Panache.withSession(() ->
+            ConnectorConfigSchema.count("connectorId", connectorId).map(count -> count > 0)
+        );
+    }
+
     // ========================================================================
     // Connector updates
     // ========================================================================

--- a/src/main/java/ai/pipestream/connector/service/ConnectorRegistrationServiceImpl.java
+++ b/src/main/java/ai/pipestream/connector/service/ConnectorRegistrationServiceImpl.java
@@ -52,10 +52,12 @@ public class ConnectorRegistrationServiceImpl extends MutinyConnectorRegistratio
     @Override
     public Uni<CreateConnectorTypeResponse> createConnectorType(CreateConnectorTypeRequest request) {
         if (request.getConnectorType() == null || request.getConnectorType().isBlank()) {
-            return Uni.createFrom().failure(new IllegalArgumentException("connector_type is required"));
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("connector_type is required").asRuntimeException());
         }
         if (request.getName() == null || request.getName().isBlank()) {
-            return Uni.createFrom().failure(new IllegalArgumentException("name is required"));
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("name is required").asRuntimeException());
         }
 
         String connectorType = request.getConnectorType().trim().toLowerCase();
@@ -87,7 +89,12 @@ public class ConnectorRegistrationServiceImpl extends MutinyConnectorRegistratio
                 .setSuccess(true)
                 .setMessage("Connector type '" + connectorType + "' created with id " + created.connectorId)
                 .setConnector(toProtoConnector(created))
-                .build());
+                .build())
+            .onFailure(e -> e instanceof org.hibernate.exception.ConstraintViolationException
+                    || (e.getCause() != null && e.getCause() instanceof org.hibernate.exception.ConstraintViolationException))
+                .recoverWithUni(e -> Uni.createFrom().failure(Status.ALREADY_EXISTS
+                    .withDescription("Connector type already exists: " + connectorType)
+                    .asRuntimeException()));
     }
 
     /**
@@ -96,7 +103,8 @@ public class ConnectorRegistrationServiceImpl extends MutinyConnectorRegistratio
     @Override
     public Uni<DeleteConnectorTypeResponse> deleteConnectorType(DeleteConnectorTypeRequest request) {
         if (request.getConnectorId() == null || request.getConnectorId().isBlank()) {
-            return Uni.createFrom().failure(new IllegalArgumentException("connector_id is required"));
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("connector_id is required").asRuntimeException());
         }
 
         return connectorRegistrationRepository.hasDataSources(request.getConnectorId())
@@ -106,10 +114,17 @@ public class ConnectorRegistrationServiceImpl extends MutinyConnectorRegistratio
                         .withDescription("Cannot delete connector type: active DataSources reference it")
                         .asRuntimeException());
                 }
-                // Also check schema references
-                return connectorRegistrationRepository.isSchemaReferencedByConnector(request.getConnectorId());
+                // Check if any schemas belong to this connector type
+                return connectorRegistrationRepository.hasSchemas(request.getConnectorId());
             })
-            .flatMap(hasSchemas -> connectorRegistrationRepository.deleteConnector(request.getConnectorId()))
+            .flatMap(hasSchemas -> {
+                if (hasSchemas) {
+                    return Uni.createFrom().<Boolean>failure(Status.FAILED_PRECONDITION
+                        .withDescription("Cannot delete connector type: config schemas still reference it")
+                        .asRuntimeException());
+                }
+                return connectorRegistrationRepository.deleteConnector(request.getConnectorId());
+            })
             .flatMap(deleted -> {
                 if (!deleted) {
                     return Uni.createFrom().failure(Status.NOT_FOUND

--- a/src/test/java/ai/pipestream/connector/service/ConnectorTypeCrudBaseTest.java
+++ b/src/test/java/ai/pipestream/connector/service/ConnectorTypeCrudBaseTest.java
@@ -2,8 +2,11 @@ package ai.pipestream.connector.service;
 
 import ai.pipestream.connector.intake.v1.CreateConnectorTypeRequest;
 import ai.pipestream.connector.intake.v1.CreateConnectorTypeResponse;
+import ai.pipestream.connector.intake.v1.CreateDataSourceRequest;
+import ai.pipestream.connector.intake.v1.CreateDataSourceResponse;
 import ai.pipestream.connector.intake.v1.DeleteConnectorTypeRequest;
 import ai.pipestream.connector.intake.v1.DeleteConnectorTypeResponse;
+import ai.pipestream.connector.intake.v1.DeleteDataSourceRequest;
 import ai.pipestream.connector.intake.v1.ListConnectorTypesRequest;
 import ai.pipestream.connector.intake.v1.ListConnectorTypesResponse;
 import ai.pipestream.connector.intake.v1.MutinyConnectorRegistrationServiceGrpc;
@@ -253,25 +256,60 @@ public abstract class ConnectorTypeCrudBaseTest {
 
     @Test
     void deleteConnectorType_withDataSources_returnsFailedPrecondition() {
-        // The pre-seeded 's3' connector has DataSources referencing it
-        // (created by other tests or production seed). Use the known S3 connector ID.
-        // This test only works if there's at least one DataSource for s3.
-        // We use ListConnectorTypes to find the s3 connector first.
-        ListConnectorTypesResponse list = adminStub().listConnectorTypes(
-            ListConnectorTypesRequest.newBuilder().build()
+        // Create a connector type, create a datasource referencing it, then try to delete
+        CreateConnectorTypeResponse created = registrationStub().createConnectorType(
+            CreateConnectorTypeRequest.newBuilder()
+                .setConnectorType("test-precondition")
+                .setName("Precondition Test")
+                .build()
         ).await().indefinitely();
 
-        var s3Connector = list.getConnectorsList().stream()
-            .filter(c -> c.getConnectorType().equals("s3"))
-            .findFirst();
+        assertThat(created.getSuccess()).as("create connector should succeed").isTrue();
+        String connectorId = created.getConnector().getConnectorId();
+        String datasourceId = null;
 
-        // If s3 connector exists, try to delete it — but this will only fail
-        // if there are DataSources. Since we can't guarantee that in isolation,
-        // we create a connector, create a datasource for it, then try to delete.
-        // For now, just verify the connector exists.
-        assertThat(s3Connector)
-            .as("s3 connector should be pre-seeded")
-            .isPresent();
+        try {
+            // Create a datasource referencing this connector type
+            CreateDataSourceResponse ds = adminStub().createDataSource(
+                CreateDataSourceRequest.newBuilder()
+                    .setAccountId("test-account")
+                    .setConnectorId(connectorId)
+                    .setName("Test DS for precondition")
+                    .setDriveName("test-drive")
+                    .build()
+            ).await().indefinitely();
+
+            assertThat(ds.getSuccess()).as("create datasource should succeed").isTrue();
+            datasourceId = ds.getDatasource().getDatasourceId();
+
+            // Now try to delete the connector type — should fail with FAILED_PRECONDITION
+            Uni<DeleteConnectorTypeResponse> deleteAttempt = registrationStub().deleteConnectorType(
+                DeleteConnectorTypeRequest.newBuilder()
+                    .setConnectorId(connectorId)
+                    .build()
+            );
+
+            StatusRuntimeException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                StatusRuntimeException.class,
+                () -> deleteAttempt.await().indefinitely()
+            );
+            assertThat(ex.getStatus().getCode())
+                .as("delete with active datasources should return FAILED_PRECONDITION")
+                .isEqualTo(io.grpc.Status.Code.FAILED_PRECONDITION);
+        } finally {
+            // Cleanup: delete datasource first, then connector type
+            if (datasourceId != null) {
+                try {
+                    adminStub().deleteDataSource(
+                        DeleteDataSourceRequest.newBuilder()
+                            .setDatasourceId(datasourceId)
+                            .setHardDelete(true)
+                            .build()
+                    ).await().indefinitely();
+                } catch (Exception ignored) {}
+            }
+            cleanupConnectorType(connectorId);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **deleteConnectorType** was calling `isSchemaReferencedByConnector(connectorId)` which checks schema→connector (wrong direction). Replaced with new `hasSchemas(connectorId)` that correctly checks `ConnectorConfigSchema.connectorId`. Also fixed the result being ignored — now returns `FAILED_PRECONDITION` if schemas exist.
- Validation failures now return `Status.INVALID_ARGUMENT` instead of `IllegalArgumentException` (which surfaced as gRPC `UNKNOWN`).
- `createConnectorType` now catches `ConstraintViolationException` and maps to `ALREADY_EXISTS` for TOCTOU race safety.
- `deleteConnectorType_withDataSources` test now fully exercises the FAILED_PRECONDITION path.

## Test plan
- [x] 10/10 unit tests pass including updated `deleteConnectorType_withDataSources_returnsFailedPrecondition`