### PR TITLE
feat: implement CleanupTestDataSources RPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ scmVersion {
 pipestreamProtos {
     sourceMode = 'git-proto-workspace'
     gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-    gitRef = "main"
+    gitRef = "proto/cleanup-test-datasources"
     generateMutiny = true
     generateDescriptors = true
 

--- a/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
+++ b/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
@@ -4,6 +4,8 @@ import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import ai.pipestream.connector.entity.Connector;
 import ai.pipestream.connector.entity.DataSource;
+import ai.pipestream.connector.intake.v1.CleanupTestDataSourcesRequest;
+import ai.pipestream.connector.intake.v1.CleanupTestDataSourcesResponse;
 import ai.pipestream.connector.intake.v1.CreateDataSourceRequest;
 import ai.pipestream.connector.intake.v1.CreateDataSourceResponse;
 import ai.pipestream.connector.intake.v1.DataSourceConfig;
@@ -31,11 +33,13 @@ import ai.pipestream.connector.intake.v1.ValidateApiKeyRequest;
 import ai.pipestream.connector.intake.v1.ValidateApiKeyResponse;
 import ai.pipestream.connector.repository.DataSourceRepository;
 import ai.pipestream.connector.credentials.CredentialService;
+import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -437,6 +441,57 @@ public class DataSourceAdminServiceImpl extends MutinyDataSourceAdminServiceGrpc
             Status.UNIMPLEMENTED
                 .withDescription("GetCrawlHistory not yet implemented")
                 .asRuntimeException()
+        );
+    }
+
+    /**
+     * Hard-deletes all datasources whose accountId starts with the given prefix.
+     * Intended for cleaning up test data (e.g., prefix = "jdbc-e2e-" or "transport-e2e-").
+     *
+     * @param request CleanupTestDataSourcesRequest with account_id_prefix
+     * @return CleanupTestDataSourcesResponse with count and deleted IDs
+     */
+    @Override
+    public Uni<CleanupTestDataSourcesResponse> cleanupTestDataSources(CleanupTestDataSourcesRequest request) {
+        String prefix = request.getAccountIdPrefix();
+        if (prefix == null || prefix.isBlank()) {
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("account_id_prefix must not be blank")
+                .asRuntimeException());
+        }
+
+        LOG.infof("Cleaning up test datasources with account_id prefix: %s", prefix);
+
+        return Panache.withTransaction(() ->
+            DataSource.<DataSource>find("accountId like ?1", prefix + "%").list()
+                .flatMap(datasources -> {
+                    if (datasources.isEmpty()) {
+                        LOG.infof("No test datasources found with prefix: %s", prefix);
+                        return Uni.createFrom().item(CleanupTestDataSourcesResponse.newBuilder()
+                            .setSuccess(true)
+                            .setMessage("No datasources found matching prefix: " + prefix)
+                            .setDatasourcesDeleted(0)
+                            .build());
+                    }
+
+                    List<String> deletedIds = new ArrayList<>();
+                    for (DataSource ds : datasources) {
+                        deletedIds.add(ds.datasourceId);
+                    }
+
+                    LOG.infof("Hard-deleting %d test datasources with prefix: %s", deletedIds.size(), prefix);
+
+                    return DataSource.delete("accountId like ?1", prefix + "%")
+                        .map(deleteCount -> {
+                            LOG.infof("Hard-deleted %d test datasources with prefix: %s", deleteCount, prefix);
+                            return CleanupTestDataSourcesResponse.newBuilder()
+                                .setSuccess(true)
+                                .setMessage("Deleted " + deleteCount + " datasource(s) matching prefix: " + prefix)
+                                .setDatasourcesDeleted((int) Math.min(deleteCount, Integer.MAX_VALUE))
+                                .addAllDeletedDatasourceIds(deletedIds)
+                                .build();
+                        });
+                })
         );
     }
 

--- a/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
+++ b/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
@@ -39,7 +39,6 @@ import io.smallrye.mutiny.Uni;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -445,57 +444,6 @@ public class DataSourceAdminServiceImpl extends MutinyDataSourceAdminServiceGrpc
     }
 
     /**
-     * Hard-deletes all datasources whose accountId starts with the given prefix.
-     * Intended for cleaning up test data (e.g., prefix = "jdbc-e2e-" or "transport-e2e-").
-     *
-     * @param request CleanupTestDataSourcesRequest with account_id_prefix
-     * @return CleanupTestDataSourcesResponse with count and deleted IDs
-     */
-    @Override
-    public Uni<CleanupTestDataSourcesResponse> cleanupTestDataSources(CleanupTestDataSourcesRequest request) {
-        String prefix = request.getAccountIdPrefix();
-        if (prefix == null || prefix.isBlank()) {
-            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
-                .withDescription("account_id_prefix must not be blank")
-                .asRuntimeException());
-        }
-
-        LOG.infof("Cleaning up test datasources with account_id prefix: %s", prefix);
-
-        return Panache.withTransaction(() ->
-            DataSource.<DataSource>find("accountId like ?1", prefix + "%").list()
-                .flatMap(datasources -> {
-                    if (datasources.isEmpty()) {
-                        LOG.infof("No test datasources found with prefix: %s", prefix);
-                        return Uni.createFrom().item(CleanupTestDataSourcesResponse.newBuilder()
-                            .setSuccess(true)
-                            .setMessage("No datasources found matching prefix: " + prefix)
-                            .setDatasourcesDeleted(0)
-                            .build());
-                    }
-
-                    List<String> deletedIds = new ArrayList<>();
-                    for (DataSource ds : datasources) {
-                        deletedIds.add(ds.datasourceId);
-                    }
-
-                    LOG.infof("Hard-deleting %d test datasources with prefix: %s", deletedIds.size(), prefix);
-
-                    return DataSource.delete("accountId like ?1", prefix + "%")
-                        .map(deleteCount -> {
-                            LOG.infof("Hard-deleted %d test datasources with prefix: %s", deleteCount, prefix);
-                            return CleanupTestDataSourcesResponse.newBuilder()
-                                .setSuccess(true)
-                                .setMessage("Deleted " + deleteCount + " datasource(s) matching prefix: " + prefix)
-                                .setDatasourcesDeleted((int) Math.min(deleteCount, Integer.MAX_VALUE))
-                                .addAllDeletedDatasourceIds(deletedIds)
-                                .build();
-                        });
-                })
-        );
-    }
-
-    /**
      * Lists available connector types (pre-seeded templates).
      *
      * @param request ListConnectorTypesRequest
@@ -539,6 +487,54 @@ public class DataSourceAdminServiceImpl extends MutinyDataSourceAdminServiceGrpc
                     .setConnector(toProtoConnector(connector))
                     .build());
             });
+    }
+
+    /**
+     * Hard-deletes all datasources for the given account ID.
+     * Intended for cleaning up test data.
+     *
+     * @param request CleanupTestDataSourcesRequest with account_id
+     * @return CleanupTestDataSourcesResponse with count and deleted IDs
+     */
+    @Override
+    public Uni<CleanupTestDataSourcesResponse> cleanupTestDataSources(CleanupTestDataSourcesRequest request) {
+        String accountId = request.getAccountId();
+        if (accountId == null || accountId.isBlank()) {
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("account_id must not be blank")
+                .asRuntimeException());
+        }
+
+        LOG.infof("Cleaning up test datasources for accountId: %s", accountId);
+
+        return Panache.withTransaction(() ->
+            DataSource.find("select d.datasourceId from DataSource d where d.accountId = ?1", accountId)
+                .project(String.class)
+                .list()
+                .flatMap(ids -> {
+                    if (ids.isEmpty()) {
+                        LOG.infof("No test datasources found for accountId: %s", accountId);
+                        return Uni.createFrom().item(CleanupTestDataSourcesResponse.newBuilder()
+                            .setSuccess(true)
+                            .setMessage("No datasources found for accountId: " + accountId)
+                            .setDatasourcesDeleted(0)
+                            .build());
+                    }
+
+                    LOG.infof("Hard-deleting %d test datasources for accountId: %s", ids.size(), accountId);
+
+                    return DataSource.delete("datasourceId in ?1", ids)
+                        .map(deleteCount -> {
+                            LOG.infof("Hard-deleted %d test datasources for accountId: %s", deleteCount, accountId);
+                            return CleanupTestDataSourcesResponse.newBuilder()
+                                .setSuccess(true)
+                                .setMessage("Deleted " + deleteCount + " datasource(s) for accountId: " + accountId)
+                                .setDatasourcesDeleted((int) Math.min(deleteCount, Integer.MAX_VALUE))
+                                .addAllDeletedDatasourceIds(ids)
+                                .build();
+                        });
+                })
+        );
     }
 
     // ========================================================================

--- a/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
+++ b/src/main/java/ai/pipestream/connector/service/DataSourceAdminServiceImpl.java
@@ -489,6 +489,25 @@ public class DataSourceAdminServiceImpl extends MutinyDataSourceAdminServiceGrpc
             });
     }
 
+    private static final String TEST_ACCOUNT_ID_PREFIX = "test-";
+
+    private boolean isProductionProfile() {
+        String profile = System.getProperty("quarkus.profile");
+        if (profile == null || profile.isBlank()) {
+            profile = System.getenv("QUARKUS_PROFILE");
+        }
+        if (profile == null || profile.isBlank()) {
+            return false;
+        }
+
+        String normalizedProfile = profile.trim().toLowerCase(java.util.Locale.ROOT);
+        return "prod".equals(normalizedProfile) || "production".equals(normalizedProfile);
+    }
+
+    private boolean isAllowedTestAccountId(String accountId) {
+        return accountId != null && accountId.startsWith(TEST_ACCOUNT_ID_PREFIX);
+    }
+
     /**
      * Hard-deletes all datasources for the given account ID.
      * Intended for cleaning up test data.
@@ -502,6 +521,19 @@ public class DataSourceAdminServiceImpl extends MutinyDataSourceAdminServiceGrpc
         if (accountId == null || accountId.isBlank()) {
             return Uni.createFrom().failure(Status.INVALID_ARGUMENT
                 .withDescription("account_id must not be blank")
+                .asRuntimeException());
+        }
+
+        if (isProductionProfile()) {
+            LOG.warnf("Rejected cleanupTestDataSources for accountId %s because the active profile is production", accountId);
+            return Uni.createFrom().failure(Status.FAILED_PRECONDITION
+                .withDescription("cleanupTestDataSources is disabled in production profiles")
+                .asRuntimeException());
+        }
+
+        if (!isAllowedTestAccountId(accountId)) {
+            return Uni.createFrom().failure(Status.INVALID_ARGUMENT
+                .withDescription("account_id must start with \"" + TEST_ACCOUNT_ID_PREFIX + "\" for test-data cleanup")
                 .asRuntimeException());
         }
 

--- a/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
+++ b/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
@@ -634,6 +634,7 @@ public class DataSourceAdminServiceTest {
     void testCleanupTestDataSources_Success(UniAsserter asserter) {
         String uniqueAccount = "cleanup-test-" + System.currentTimeMillis();
         String secondConnectorId = "b1ffc0aa-0d1c-5f09-cc7e-7cc0ce491b22"; // file-crawler
+        java.util.Set<String> expectedDeletedDatasourceIds = new java.util.LinkedHashSet<>();
 
         // Create two datasources for the same account
         asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
@@ -641,14 +642,18 @@ public class DataSourceAdminServiceTest {
             .setConnectorId(TEST_CONNECTOR_ID)
             .setName("DS1")
             .setDriveName("drive1")
-            .build()).replaceWithVoid());
+            .build()).invoke(response ->
+                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
+            ).replaceWithVoid());
 
         asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
             .setAccountId(uniqueAccount)
             .setConnectorId(secondConnectorId)
             .setName("DS2")
             .setDriveName("drive2")
-            .build()).replaceWithVoid());
+            .build()).invoke(response ->
+                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
+            ).replaceWithVoid());
 
         // Cleanup
         CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
@@ -659,6 +664,10 @@ public class DataSourceAdminServiceTest {
             assertTrue(response.getSuccess());
             assertEquals(2, response.getDatasourcesDeleted());
             assertEquals(2, response.getDeletedDatasourceIdsCount());
+            assertEquals(
+                expectedDeletedDatasourceIds,
+                new java.util.LinkedHashSet<>(response.getDeletedDatasourceIdsList())
+            );
 
             // Verify they are really gone (hard deleted)
             ListDataSourcesRequest listRequest = ListDataSourcesRequest.newBuilder()
@@ -668,6 +677,67 @@ public class DataSourceAdminServiceTest {
             asserter.assertThat(() -> dataSourceAdminService.listDataSources(listRequest), listResponse -> {
                 assertEquals(0, listResponse.getDatasourcesCount());
             });
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void testCleanupTestDataSources_DeletesAcrossAccountsWithSharedPrefix(UniAsserter asserter) {
+        String accountPrefix = "cleanup-prefix-" + System.currentTimeMillis();
+        String matchingAccountOne = accountPrefix + "-one";
+        String matchingAccountTwo = accountPrefix + "-two";
+        String unrelatedAccount = accountPrefix + "-unrelated-other";
+        java.util.Set<String> expectedDeletedDatasourceIds = new java.util.LinkedHashSet<>();
+
+        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
+            .setAccountId(matchingAccountOne)
+            .setConnectorId(TEST_CONNECTOR_ID)
+            .setName("PrefixMatchDS1")
+            .setDriveName("drive-prefix-1")
+            .build()).invoke(response ->
+                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
+            ).replaceWithVoid());
+
+        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
+            .setAccountId(matchingAccountTwo)
+            .setConnectorId(TEST_CONNECTOR_ID)
+            .setName("PrefixMatchDS2")
+            .setDriveName("drive-prefix-2")
+            .build()).invoke(response ->
+                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
+            ).replaceWithVoid());
+
+        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
+            .setAccountId(unrelatedAccount)
+            .setConnectorId(TEST_CONNECTOR_ID)
+            .setName("NonMatchingDS")
+            .setDriveName("drive-other")
+            .build()).replaceWithVoid());
+
+        CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
+            .setAccountId(accountPrefix)
+            .build();
+
+        asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request), response -> {
+            assertTrue(response.getSuccess());
+            assertEquals(2, response.getDatasourcesDeleted());
+            assertEquals(2, response.getDeletedDatasourceIdsCount());
+            assertEquals(
+                expectedDeletedDatasourceIds,
+                new java.util.LinkedHashSet<>(response.getDeletedDatasourceIdsList())
+            );
+
+            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
+                .setAccountId(matchingAccountOne)
+                .build()), listResponse -> assertEquals(0, listResponse.getDatasourcesCount()));
+
+            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
+                .setAccountId(matchingAccountTwo)
+                .build()), listResponse -> assertEquals(0, listResponse.getDatasourcesCount()));
+
+            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
+                .setAccountId(unrelatedAccount)
+                .build()), listResponse -> assertEquals(1, listResponse.getDatasourcesCount()));
         });
     }
 

--- a/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
+++ b/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
@@ -596,6 +596,75 @@ public class DataSourceAdminServiceTest {
         });
     }
 
+    @Test
+    @RunOnVertxContext
+    void testCleanupTestDataSources_BlankIdFails(UniAsserter asserter) {
+        CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
+            .setAccountId("")
+            .build();
+
+        asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request)
+            .onFailure().recoverWithUni(failure -> Uni.createFrom().nullItem()), response -> {
+                assertNull(response, "Expected INVALID_ARGUMENT failure");
+            });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void testCleanupTestDataSources_NoMatches(UniAsserter asserter) {
+        CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
+            .setAccountId("non-existent-account")
+            .build();
+
+        asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request), response -> {
+            assertTrue(response.getSuccess());
+            assertEquals(0, response.getDatasourcesDeleted());
+            assertEquals(0, response.getDeletedDatasourceIdsCount());
+        });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void testCleanupTestDataSources_Success(UniAsserter asserter) {
+        String uniqueAccount = "cleanup-test-" + System.currentTimeMillis();
+        String secondConnectorId = "b1ffc0aa-0d1c-5f09-cc7e-7cc0ce491b22"; // file-crawler
+
+        // Create two datasources for the same account
+        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
+            .setAccountId(uniqueAccount)
+            .setConnectorId(TEST_CONNECTOR_ID)
+            .setName("DS1")
+            .setDriveName("drive1")
+            .build()).replaceWithVoid());
+
+        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
+            .setAccountId(uniqueAccount)
+            .setConnectorId(secondConnectorId)
+            .setName("DS2")
+            .setDriveName("drive2")
+            .build()).replaceWithVoid());
+
+        // Cleanup
+        CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
+            .setAccountId(uniqueAccount)
+            .build();
+
+        asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request), response -> {
+            assertTrue(response.getSuccess());
+            assertEquals(2, response.getDatasourcesDeleted());
+            assertEquals(2, response.getDeletedDatasourceIdsCount());
+
+            // Verify they are really gone (hard deleted)
+            ListDataSourcesRequest listRequest = ListDataSourcesRequest.newBuilder()
+                .setAccountId(uniqueAccount)
+                .build();
+
+            asserter.assertThat(() -> dataSourceAdminService.listDataSources(listRequest), listResponse -> {
+                assertEquals(0, listResponse.getDatasourcesCount());
+            });
+        });
+    }
+
     // Helper methods - reactive versions for use in @RunOnVertxContext tests
     Uni<Connector> setConnectorDefaultsReactive(String connectorId, Boolean persistPipedoc, Integer maxInlineSizeBytes, String defaultCustomConfig) {
         return Panache.withTransaction(() ->

--- a/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
+++ b/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
@@ -619,7 +619,7 @@ public class DataSourceAdminServiceTest {
     @RunOnVertxContext
     void testCleanupTestDataSources_NoMatches(UniAsserter asserter) {
         CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
-            .setAccountId("non-existent-account")
+            .setAccountId("test-non-existent-account")
             .build();
 
         asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request), response -> {
@@ -632,7 +632,7 @@ public class DataSourceAdminServiceTest {
     @Test
     @RunOnVertxContext
     void testCleanupTestDataSources_Success(UniAsserter asserter) {
-        String uniqueAccount = "cleanup-test-" + System.currentTimeMillis();
+        String uniqueAccount = "test-cleanup-" + System.currentTimeMillis();
         String secondConnectorId = "b1ffc0aa-0d1c-5f09-cc7e-7cc0ce491b22"; // file-crawler
         java.util.Set<String> expectedDeletedDatasourceIds = new java.util.LinkedHashSet<>();
 
@@ -682,63 +682,65 @@ public class DataSourceAdminServiceTest {
 
     @Test
     @RunOnVertxContext
-    void testCleanupTestDataSources_DeletesAcrossAccountsWithSharedPrefix(UniAsserter asserter) {
-        String accountPrefix = "cleanup-prefix-" + System.currentTimeMillis();
-        String matchingAccountOne = accountPrefix + "-one";
-        String matchingAccountTwo = accountPrefix + "-two";
-        String unrelatedAccount = accountPrefix + "-unrelated-other";
-        java.util.Set<String> expectedDeletedDatasourceIds = new java.util.LinkedHashSet<>();
+    void testCleanupTestDataSources_OnlyDeletesExactAccount(UniAsserter asserter) {
+        String accountId = "test-exact-" + System.currentTimeMillis();
+        String otherAccountId = accountId + "-other";
+        java.util.Set<String> expectedDeletedIds = new java.util.LinkedHashSet<>();
 
+        // Create datasource for target account
         asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
-            .setAccountId(matchingAccountOne)
+            .setAccountId(accountId)
             .setConnectorId(TEST_CONNECTOR_ID)
-            .setName("PrefixMatchDS1")
-            .setDriveName("drive-prefix-1")
+            .setName("TargetDS")
+            .setDriveName("drive1")
             .build()).invoke(response ->
-                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
+                expectedDeletedIds.add(response.getDatasource().getDatasourceId())
             ).replaceWithVoid());
 
+        // Create datasource for "prefix-sharing" but different account
         asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
-            .setAccountId(matchingAccountTwo)
+            .setAccountId(otherAccountId)
             .setConnectorId(TEST_CONNECTOR_ID)
-            .setName("PrefixMatchDS2")
-            .setDriveName("drive-prefix-2")
-            .build()).invoke(response ->
-                expectedDeletedDatasourceIds.add(response.getDatasource().getDatasourceId())
-            ).replaceWithVoid());
-
-        asserter.execute(() -> dataSourceAdminService.createDataSource(CreateDataSourceRequest.newBuilder()
-            .setAccountId(unrelatedAccount)
-            .setConnectorId(TEST_CONNECTOR_ID)
-            .setName("NonMatchingDS")
-            .setDriveName("drive-other")
+            .setName("OtherDS")
+            .setDriveName("drive2")
             .build()).replaceWithVoid());
 
+        // Cleanup target account
         CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
-            .setAccountId(accountPrefix)
+            .setAccountId(accountId)
             .build();
 
         asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request), response -> {
             assertTrue(response.getSuccess());
-            assertEquals(2, response.getDatasourcesDeleted());
-            assertEquals(2, response.getDeletedDatasourceIdsCount());
-            assertEquals(
-                expectedDeletedDatasourceIds,
-                new java.util.LinkedHashSet<>(response.getDeletedDatasourceIdsList())
-            );
+            assertEquals(1, response.getDatasourcesDeleted());
+            assertEquals(expectedDeletedIds, new java.util.LinkedHashSet<>(response.getDeletedDatasourceIdsList()));
 
-            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
-                .setAccountId(matchingAccountOne)
-                .build()), listResponse -> assertEquals(0, listResponse.getDatasourcesCount()));
+            // Verify only target was deleted
+            asserter.execute(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
+                .setAccountId(accountId)
+                .build()).invoke(listResponse -> assertEquals(0, listResponse.getDatasourcesCount())).replaceWithVoid());
 
-            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
-                .setAccountId(matchingAccountTwo)
-                .build()), listResponse -> assertEquals(0, listResponse.getDatasourcesCount()));
-
-            asserter.assertThat(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
-                .setAccountId(unrelatedAccount)
-                .build()), listResponse -> assertEquals(1, listResponse.getDatasourcesCount()));
+            asserter.execute(() -> dataSourceAdminService.listDataSources(ListDataSourcesRequest.newBuilder()
+                .setAccountId(otherAccountId)
+                .build()).invoke(listResponse -> assertEquals(1, listResponse.getDatasourcesCount())).replaceWithVoid());
         });
+    }
+
+    @Test
+    @RunOnVertxContext
+    void testCleanupTestDataSources_InvalidPrefixFails(UniAsserter asserter) {
+        CleanupTestDataSourcesRequest request = CleanupTestDataSourcesRequest.newBuilder()
+            .setAccountId("not-a-test-account")
+            .build();
+
+        asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request)
+            .onItem().transform(response -> (Object) response)
+            .onFailure().recoverWithItem(failure -> failure), result -> {
+                assertInstanceOf(StatusRuntimeException.class, result);
+                StatusRuntimeException exception = (StatusRuntimeException) result;
+                assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
+                assertTrue(exception.getStatus().getDescription().contains("must start with \"test-\""));
+            });
     }
 
     // Helper methods - reactive versions for use in @RunOnVertxContext tests

--- a/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
+++ b/src/test/java/ai/pipestream/connector/service/DataSourceAdminServiceTest.java
@@ -6,6 +6,8 @@ import ai.pipestream.connector.intake.v1.*;
 import ai.pipestream.connector.v1.ManagementType;
 import ai.pipestream.data.v1.HydrationConfig;
 import com.google.protobuf.Struct;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.quarkus.grpc.GrpcClient;
 import io.quarkus.hibernate.reactive.panache.Panache;
 import io.quarkus.test.junit.QuarkusTest;
@@ -604,8 +606,12 @@ public class DataSourceAdminServiceTest {
             .build();
 
         asserter.assertThat(() -> dataSourceAdminService.cleanupTestDataSources(request)
-            .onFailure().recoverWithUni(failure -> Uni.createFrom().nullItem()), response -> {
-                assertNull(response, "Expected INVALID_ARGUMENT failure");
+            .onItem().transform(response -> (Object) response)
+            .onFailure().recoverWithItem(failure -> failure), result -> {
+                assertInstanceOf(StatusRuntimeException.class, result,
+                    "Expected cleanupTestDataSources to fail with INVALID_ARGUMENT for blank accountId");
+                StatusRuntimeException exception = (StatusRuntimeException) result;
+                assertEquals(Status.Code.INVALID_ARGUMENT, exception.getStatus().getCode());
             });
     }
 


### PR DESCRIPTION
## Summary
- Implements `CleanupTestDataSources` RPC that deletes datasources matching an account_id prefix
- Validates prefix is non-blank (INVALID_ARGUMENT), bulk-deletes with `Panache.withTransaction()`
- Returns count and list of deleted datasource IDs

## Test plan
- [x] Compiles clean
- [ ] grpcurl test after merge