### PR TITLE
chore: point pipestreamProtos back to main branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ scmVersion {
 pipestreamProtos {
     sourceMode = 'git-proto-workspace'
     gitRepo = "https://github.com/ai-pipestream/pipestream-protos.git"
-    gitRef = "proto/cleanup-test-datasources"
+    gitRef = "main"
     generateMutiny = true
     generateDescriptors = true
 


### PR DESCRIPTION
Now that the corresponding proto PR (ai-pipestream/pipestream-protos#34) has been merged into main, this PR points `build.gradle` back to the `main` branch of `pipestream-protos`.